### PR TITLE
Add name_port_gpio.py to this repo. Someone else might find useful.

### DIFF
--- a/name_port_gpio.py
+++ b/name_port_gpio.py
@@ -1,0 +1,54 @@
+""" name_port_gpio.py
+ 
+    This is a demo python file showing how to take paramaters
+    from command line for device name, port, and GPIO.
+    All credit goes to https://github.com/toddmedema/echo/
+    for making the first working versions of this code.
+"""
+ 
+import fauxmo
+import logging
+import time
+import sys
+import RPi.GPIO as GPIO ## Import GPIO library
+ 
+from debounce_handler import debounce_handler
+ 
+logging.basicConfig(level=logging.DEBUG)
+ 
+class device_handler(debounce_handler):
+    """Publishes the on/off state requested,
+       and the IP address of the Echo making the request.
+    """
+    TRIGGERS = {str(sys.argv[1]): int(sys.argv[2])}
+ 
+    def act(self, client_address, state):
+        print "State", state, "from client @", client_address
+        GPIO.setmode(GPIO.BOARD) ## Use board pin numbering
+        GPIO.setup(int(sys.argv[3]), GPIO.OUT)   ## Setup GPIO Pin to OUTPUT
+        GPIO.output(int(sys.argv[3]), not state) ## State is true/false
+        return True
+ 
+if __name__ == "__main__":
+    # Startup the fauxmo server
+    fauxmo.DEBUG = True
+    p = fauxmo.poller()
+    u = fauxmo.upnp_broadcast_responder()
+    u.init_socket()
+    p.add(u)
+ 
+    # Register the device callback as a fauxmo handler
+    d = device_handler()
+    for trig, port in d.TRIGGERS.items():
+        fauxmo.fauxmo(trig, u, p, None, port, d)
+ 
+    # Loop and poll for incoming Echo requests
+    logging.debug("Entering fauxmo polling loop")
+    while True:
+        try:
+            # Allow time for a ctrl-c to stop the process
+            p.poll(100)
+            time.sleep(0.1)
+        except Exception, e:
+            logging.critical("Critical exception: " + str(e))
+            break


### PR DESCRIPTION
Maybe someone finds this script useful, it allows multiple instances of the script to run controlling accepting different names and controlling gpio from the command line, something like this should work:

/usr/bin/python /home/pi/echo/echo-master/name_port_gpio.py coffeemachine    52000 3 &
/usr/bin/python /home/pi/echo/echo-master/name_port_gpio.py toaster                52001 5 &
