### PR TITLE
bring in device name into example

### DIFF
--- a/debounce_handler.py
+++ b/debounce_handler.py
@@ -9,15 +9,15 @@ class debounce_handler(object):
     def __init__(self):
         self.lastEcho = time.time()
 
-    def on(self, client_address):
+    def on(self, client_address, name):
         if self.debounce():
             return True
-        return self.act(client_address, True)
+        return self.act(client_address, True, name)
 
-    def off(self, client_address):
+    def off(self, client_address, name):
         if self.debounce():
             return True
-        return self.act(client_address, False)
+        return self.act(client_address, False, name)
 
     def act(self, client_address, state):
         pass

--- a/example-minimal.py
+++ b/example-minimal.py
@@ -26,8 +26,8 @@ class device_handler(debounce_handler):
     """
     TRIGGERS = {"device": 52000}
 
-    def act(self, client_address, state):
-        print "State", state, "from client @", client_address
+    def act(self, client_address, state, name):
+        print "State", state, "on ", name, "from client @", client_address
         return True
 
 if __name__ == "__main__":

--- a/fauxmo.py
+++ b/fauxmo.py
@@ -223,11 +223,11 @@ class fauxmo(upnp_device):
             if data.find('<BinaryState>1</BinaryState>') != -1:
                 # on
                 dbg("Responding to ON for %s" % self.name)
-                success = self.action_handler.on(client_address[0])
+                success = self.action_handler.on(client_address[0], self.name)
             elif data.find('<BinaryState>0</BinaryState>') != -1:
                 # off
                 dbg("Responding to OFF for %s" % self.name)
-                success = self.action_handler.off(client_address[0])
+                success = self.action_handler.off(client_address[0], self.name)
             else:
                 dbg("Unknown Binary State request:")
                 dbg(data)


### PR DESCRIPTION
This makes the name of the device available. I kinda translate my current API for home automation in this way so i can use it with alexa:

 if name is "foobar":
            if state:
                urllib2.urlopen("https://some_host/switch.php?id=foobar&cmd=1").read()
            else:
                urllib2.urlopen("https://some_host/switch.php?id=foobar&cmd=0").read()